### PR TITLE
Update base URL for data registry in tests

### DIFF
--- a/tests/test_ort_file.py
+++ b/tests/test_ort_file.py
@@ -34,7 +34,7 @@ def make_pooch(base_url: str, registry: dict[str, str | None]) -> pooch.Pooch:
 @pytest.fixture(scope='module')
 def data_registry():
     return make_pooch(
-        base_url='https://pub-6c25ef91903d4301a3338bd53b370098.r2.dev',
+        base_url='https://github.com/scipp/ess/releases/download/reduced_data_nightly',
         registry={
             'amor_reduced_iofq.ort': None,
         },


### PR DESCRIPTION
We make nightly releases of reduced files on github now, so no need for this R2 bucket :)

https://github.com/scipp/ess/releases/tag/reduced_data_nightly